### PR TITLE
fix a small error in build script

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -49,5 +49,5 @@ source ${BASE_DIR}/hack/build-funcs.sh
 
 check_license
 go_fmt
-go_test
 go_build
+go_test


### PR DESCRIPTION
# Changes

Make a small change in `hack/build.sh`, to run `go-build` first before `go-test`.