### PR TITLE
Fixed incorrect license Copyright in test files

### DIFF
--- a/core/root_test.go
+++ b/core/root_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/command/service/clean_test.go
+++ b/pkg/command/service/clean_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/command/service/generate_test.go
+++ b/pkg/command/service/generate_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/command/service/measure_test.go
+++ b/pkg/command/service/measure_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/command/service/service_test.go
+++ b/pkg/command/service/service_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/command/utils/util_test.go
+++ b/pkg/command/utils/util_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/command/version/version_test.go
+++ b/pkg/command/version/version_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/testutil/command.go
+++ b/pkg/testutil/command.go
@@ -1,4 +1,4 @@
-// Copyright © 2020 The Knative Authors
+// Copyright 2020 The Knative Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
After unit tests files https://github.com/knative-sandbox/kperf/pull/15 added, need to fix incorrect license Copyright in test files like https://github.com/knative-sandbox/kperf/pull/29
<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->


<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
