### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ for name in {1..10};do kubectl create ns test-$name;done
 ### generate Knative Service deployment load
 ```shell script
 # Generate total 30 knative service, for each 15 seconds create 10 ksvc with 5 concurrency in namespace test-1, test-2
-# and test-33, and the ksvc names are ktest-0, ktest-1.....ktest-29.
+# and test-3, and the ksvc names are ktest-0, ktest-1.....ktest-29.
 $ kperf service generate -n 30 -b 10 -c 5 -i 15 --namespace-prefix test --namespace-range 1,3 --svc-prefix ktest --max-scale 1 --min-scale 1
 
 Creating ksvc ktest-0 in namespace test-1


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes


Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :bug: Fix bug



<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind documentation


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
When I read the README.md today, I find there's typo for namespace test-33, it should be test-3. and this is very simple, so not create issue.


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
