### PR TITLE
Remove whitelist terminology

### DIFF
--- a/test/test-infra/README.md
+++ b/test/test-infra/README.md
@@ -220,7 +220,7 @@ benchmarking jobs for each repo. To use it:
    - `SERVICE_ACCOUNT_NAME`: Service account name for controlling GKE clusters
      and interacting with [Mako](https://github.com/google/mako) server. It MUST
      have `Kubernetes Engine Admin` and `Storage Admin` role, and be
-     [whitelisted](https://github.com/google/mako/blob/master/docs/ACCESS.md) by
+     [allowed](https://github.com/google/mako/blob/master/docs/ACCESS.md) by
      Mako admin. Defaults to `mako-job`.
 
 1. [optional] Customize root path of the benchmarks. This root folder should


### PR DESCRIPTION
As per title, this slipped through the cracks as the repo currently has no automation setuo. That should follow soon.