### PR TITLE
Add CODEOWNERS file for approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Default owners are Productivity WG leads, kperf owners and TOC
+* @knative-sandbox/technical-oversight-committee
+* @knative-sandbox/knative-release-leads
+* @knative-sandbox/productivity-wg-leads
+# Last match takes precedence for reviews
+* @knative-sandbox/kperf-approvers


### PR DESCRIPTION
cc @maximilien @zhanggbj 

The new team is being created here: https://github.com/knative/community/pull/483

This won't take effect until some additional changes to the Prow configuration land, but once they do `/lgtm /approve` will be replaced with approving through the Github code review UI.