### PR TITLE
Drop dependency on pkg/errors and use stdlib instead

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/montanaflynn/stats v0.6.3
 	github.com/pelletier/go-toml v1.8.0 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.6.2
 	gotest.tools v2.2.0+incompatible

--- a/pkg/command/service/generate.go
+++ b/pkg/command/service/generate.go
@@ -16,6 +16,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -31,7 +32,6 @@ import (
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingv1client "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"knative.dev/kperf/pkg"
@@ -90,9 +90,9 @@ kperf service generate -n 500 --interval 20 --batch 20 --min-scale 0 --max-scale
 			for _, ns := range nsNameList {
 				_, err := p.ClientSet.CoreV1().Namespaces().Get(context.TODO(), ns, metav1.GetOptions{})
 				if err != nil && apierrors.IsNotFound(err) {
-					return errors.Errorf("namespace %s not found, please create one", ns)
+					return fmt.Errorf("namespace %s not found, please create one", ns)
 				} else if err != nil {
-					return errors.Wrap(err, "failed to get namespace")
+					return fmt.Errorf("failed to get namespace: %w", err)
 				}
 			}
 
@@ -146,7 +146,7 @@ kperf service generate -n 500 --interval 20 --batch 20 --min-scale 0 --max-scale
 					}
 				}
 				fmt.Printf("Error: Knative Service %s in namespace %s is not ready after %s\n", name, ns, generateArgs.timeout)
-				return errors.Errorf("Knative Service %s in namespace %s is not ready after %s ", name, ns, generateArgs.timeout)
+				return fmt.Errorf("Knative Service %s in namespace %s is not ready after %s ", name, ns, generateArgs.timeout)
 
 			}
 			if generateArgs.checkReady {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,7 +75,6 @@ github.com/montanaflynn/stats
 ## explicit
 github.com/pelletier/go-toml
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/spf13/afero v1.2.2
 github.com/spf13/afero


### PR DESCRIPTION
As per title really. This dependency has been superseded by stdlib enhancements and is no longer necessary. We ditched it in other repos, so let's ditch here too!