### PR TITLE
Store measurement result into a JSON file

### DIFF
--- a/pkg/command/service/common.go
+++ b/pkg/command/service/common.go
@@ -41,6 +41,7 @@ type cleanArgs struct {
 	svcPrefix       string
 	concurrency     int
 }
+
 type measureArgs struct {
 	svcRange        string
 	namespace       string
@@ -50,6 +51,7 @@ type measureArgs struct {
 	concurrency     int
 	verbose         bool
 }
+
 type measureResult struct {
 	svcConfigurationsReadySum         float64
 	svcRoutesReadySum                 float64
@@ -67,11 +69,50 @@ type measureResult struct {
 	queueProxyStartedSum              float64
 	userContrainerStartedSum          float64
 	deploymentCreatedSum              float64
+	Result                            result
+	Service                           serviceCount
+	svcReadyTime                      []float64
+	KnativeInfo                       knativeInfo
+}
 
-	readyCount    int
-	notReadyCount int
-	notFoundCount int
-	failCount     int
+type serviceCount struct {
+	ReadyCount    int `json:"Ready"`
+	NotReadyCount int `json:"NotReady"`
+	NotFoundCount int `json:"NotFound"`
+	FailCount     int `json:"Fail"`
+}
 
-	svcReadyTime []float64
+type knativeInfo struct {
+	ServingVersion    string
+	EventingVersion   string
+	IngressController string
+	IngressVersion    string
+}
+
+type result struct {
+	AverageSvcConfigurationReadySum          float64 `json:"AverageConfigurationDuration"`
+	AverageRevisionReadySum                  float64 `json:"AverageRevisionDuration"`
+	AverageDeploymentCreatedSum              float64 `json:"AverageDeploymentDuration"`
+	AveragePodScheduledSum                   float64 `json:"AveragePodScheduleDuration"`
+	AverageContainersReadySum                float64 `json:"AveragePodContainersReadyDuration"`
+	AverageQueueProxyStartedSum              float64 `json:"AveragePodQueueProxyStartedDuration"`
+	AverageUserContrainerStartedSum          float64 `json:"AveragePodUserContainerStartedDuration"`
+	AverageKpaActiveSum                      float64 `json:"AverageAutoscalerActiveDuration"`
+	AverageSksReadySum                       float64 `json:"AverageServiceReadyDuration"`
+	AverageSksActivatorEndpointsPopulatedSum float64 `json:"AverageServiceActivatorEndpointsPopulatedDuration"`
+	AverageSksEndpointsPopulatedSum          float64 `json:"AverageServiceEndpointsPopulatedDuration"`
+	AverageSvcRoutesReadySum                 float64 `json:"AverageServiceRouteReadyDuration"`
+	AverageIngressReadySum                   float64 `json:"AverageIngressReadyDuration"`
+	AverageIngressNetworkConfiguredSum       float64 `json:"AverageIngressNetworkConfiguredDuration"`
+	AverageIngressLoadBalancerReadySum       float64 `json:"AverageIngressLoadBalancerReadyDuration"`
+	OverallTotal                             float64 `json:"Total"`
+	OverallAverage                           float64 `json:"Average"`
+	OverallMedian                            float64 `json:"Median"`
+	OverallMin                               float64 `json:"Min"`
+	OverallMax                               float64 `json:"Max"`
+	P50                                      float64 `json:"Percentile50"`
+	P90                                      float64 `json:"Percentile90"`
+	P95                                      float64 `json:"Percentile95"`
+	P98                                      float64 `json:"Percentile98"`
+	P99                                      float64 `json:"Percentile99"`
 }

--- a/pkg/command/utils/util.go
+++ b/pkg/command/utils/util.go
@@ -57,3 +57,18 @@ func GenerateHTMLFile(sourceCSV string, targetHTML string) error {
 		"Data": string(data),
 	})
 }
+
+func GenerateJSONFile(jsonData []byte, targetJSON string) error {
+	jsonFile, err := os.OpenFile(targetJSON, os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to create json file %s", err)
+	}
+	defer jsonFile.Close()
+
+	_, err = jsonFile.Write(jsonData)
+	if err != nil {
+		fmt.Println("failed to write json data", err)
+		return err
+	}
+	return nil
+}

--- a/pkg/command/utils/util_test.go
+++ b/pkg/command/utils/util_test.go
@@ -16,8 +16,10 @@ package utils
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"html/template"
+	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -104,5 +106,40 @@ func TestGenerateHTMLFile(t *testing.T) {
 		targetHTML := "/tmp/test.html"
 		err := GenerateHTMLFile(sourceCSV, targetHTML)
 		assert.ErrorContains(t, err, "failed to load asset")
+	})
+}
+
+func TestGenerateJSONFile(t *testing.T) {
+	t.Run("generate JSON file successfully", func(t *testing.T) {
+		type Test struct {
+			Name string
+			Age  int
+		}
+		cat := Test{
+			Name: "Cat",
+			Age:  2,
+		}
+		data, _ := json.Marshal(cat)
+		path := "/tmp/test.json"
+		err := GenerateJSONFile(data, path)
+		assert.NilError(t, err)
+		fileData, err := ioutil.ReadFile(path)
+		assert.NilError(t, err)
+		assert.Equal(t, string(fileData), "{\"Name\":\"Cat\",\"Age\":2}")
+	})
+
+	t.Run("return error if path is not available", func(t *testing.T) {
+		type Test struct {
+			Name string
+			Age  int
+		}
+		cat := Test{
+			Name: "Cat",
+			Age:  2,
+		}
+		data, _ := json.Marshal(cat)
+		path := "/tmp"
+		err := GenerateJSONFile(data, path)
+		assert.ErrorContains(t, err, "failed to create json file open /tmp: is a directory")
 	})
 }


### PR DESCRIPTION
As #34 mentioned, this change stores the measurement result into a JSON file. For example:
```
......
Raw Timestamp saved in CSV file /tmp/20210308180039_raw_ksvc_creation_time.csv
Measurement saved in CSV file /tmp/20210308180039_ksvc_creation_time.csv
Measurement saved in JSON file /tmp/20210308180039_ksvc_creation_time.json
Visualized measurement saved in HTML file /tmp/20210308180039_ksvc_creation_time.html
```
And its content is below:
```
{"Result":{"AverageConfigurationDuration":395934.1111111111,"AverageRevisionDuration":395933.22222222225,"AverageDeploymentDuration":395794.6666666667,"AveragePodScheduleDuration":0,"AveragePodContainersReadyDuration":0,"AveragePodQueueProxyStartedDuration":0,"AveragePodUserContainerStartedDuration":0,"AverageAutoscalerActiveDuration":182.05555555555554,"AverageServiceReadyDuration":182.44444444444446,"AverageServiceActivatorEndpointsPopulatedDuration":11.61111111111111,"AverageServiceEndpointsPopulatedDuration":182.44444444444446,"AverageServiceRouteReadyDuration":395939.8888888889,"AverageIngressReadyDuration":3.7777777777777777,"AverageIngressNetworkConfiguredDuration":2,"AverageIngressLoadBalancerReadyDuration":1.7777777777777777,"Total":7126918,"Average":395939.8888888889,"Median":444695.5,"Min":22,"Max":446229,"Percentile50":444695,"Percentile90":446215.5,"Percentile95":446227.5,"Percentile98":446227.5,"Percentile99":446227.5},"Service":{"Ready":18,"NotReady":0,"NotFound":0,"Fail":0},"KnativeInfo":{"ServingVersion":"0.20.0","EventingVersion":"0.20.0","IngressController":"Istio","IngressVersion":"1.7.3"}}
```
If you parse the format of above content, it will be shown as below:
```
{
    "Result":{
        "AverageConfigurationDuration":395934.1111111111,
        "AverageRevisionDuration":395933.22222222225,
        "AverageDeploymentDuration":395794.6666666667,
        "AveragePodScheduleDuration":0,
        "AveragePodContainersReadyDuration":0,
        "AveragePodQueueProxyStartedDuration":0,
        "AveragePodUserContainerStartedDuration":0,
        "AverageAutoscalerActiveDuration":182.05555555555554,
        "AverageServiceReadyDuration":182.44444444444446,
        "AverageServiceActivatorEndpointsPopulatedDuration":11.61111111111111,
        "AverageServiceEndpointsPopulatedDuration":182.44444444444446,
        "AverageServiceRouteReadyDuration":395939.8888888889,
        "AverageIngressReadyDuration":3.7777777777777777,
        "AverageIngressNetworkConfiguredDuration":2,
        "AverageIngressLoadBalancerReadyDuration":1.7777777777777777,
        "Total":7126918,
        "Average":395939.8888888889,
        "Median":444695.5,
        "Min":22,
        "Max":446229,
        "Percentile50":444695,
        "Percentile90":446215.5,
        "Percentile95":446227.5,
        "Percentile98":446227.5,
        "Percentile99":446227.5
    },
    "Service":{
        "Ready":18,
        "NotReady":0,
        "NotFound":0,
        "Fail":0
    },
    "KnativeInfo":{
        "ServingVersion":"0.20.0",
        "EventingVersion":"0.20.0",
        "IngressController":"Istio",
        "IngressVersion":"1.7.3"
    }
}
```