### PR TITLE
add retry in the measure step when the services are not ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Test binary, build with `go test -c`
 *.test
 
+# Vendor libraries
+vendor
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 cover.html

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ stability, scalability and performance bottleneck.
 ```cassandraql
 # format and build kperf
 $ cd {workspace}/src/knative.dev/kperf
-$ go get -u github.com/jteeuwen/go-bindata/...
+$ go get -u github.com/kevinburke/go-bindata/...
 $ export PATH=$PATH:$GOPATH/bin
 $ ./hack/build.sh
 

--- a/pkg/command/service/common.go
+++ b/pkg/command/service/common.go
@@ -49,6 +49,7 @@ type measureArgs struct {
 	namespaceRange  string
 	namespacePrefix string
 	concurrency     int
+	svcReadyTimeout int
 	verbose         bool
 	output          string
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Add a new flag `--svc-ready-timeout` for `measure` command, which indicates the `Duration (seconds) to wait for the service to become ready`:
- When `--svc-ready-timeout` is `0` (default): if the current service is not ready, count it as the `NotReady` service, like what we did it before
- When `--svc-ready-timeout` is upper than `0`, like `60` (seconds): if the current service is not ready, check on it's creation timestamp
  - if it's created 60s ago, count it as the `NotReady` service
  - if it has been created within 60s, put it back into the service checklist and give it another chance to be measured

# Logs

Without the change, when we run the `measure` command immediately after the `generate` is done, we may find many unready services:
```
$ kperf service measure -c 2 --namespace test-1 --svc-prefix jiao --range 1,5
service jiao-2/test-1 not ready and skip measuring
service jiao-3/test-1 not ready and skip measuring
service jiao-4/test-1 not ready and skip measuring
-------- Measurement --------
......
-----------------------------
Overall Service Ready Measurement:
Total: 5 | Ready: 2 (40.00%)  NotReady: 3 (60.00%)  NotFound: 0 (0.00%)  Fail: 0 (0.00%)
......
```

With the change, when we run the `measure` command immediately after the `generate` is done, we may see some services are not ready for times but will finally get ready:
```
$ kperf service measure -c 2 --namespace test-1 --svc-prefix jiao --range 0,4 --svc-ready-timeout 20
service jiao-0/test-1 not ready and will be re-measured later
service jiao-1/test-1 not ready and will be re-measured later
service jiao-3/test-1 not ready and will be re-measured later
service jiao-2/test-1 not ready and will be re-measured later
service jiao-4/test-1 not ready and will be re-measured later
service jiao-0/test-1 not ready and will be re-measured later
service jiao-1/test-1 not ready and will be re-measured later
service jiao-3/test-1 not ready and will be re-measured later
......
-------- Measurement --------
.....
-----------------------------
Overall Service Ready Measurement:
Total: 5 | Ready: 5 (100.00%)  NotReady: 0 (0.00%)  NotFound: 0 (0.00%)  Fail: 0 (0.00%) 
......
```

