### PR TITLE
Add --verbose flag for debugging purpose

### DIFF
--- a/pkg/command/service/common.go
+++ b/pkg/command/service/common.go
@@ -14,6 +14,7 @@
 package service
 
 import (
+	"sync"
 	"time"
 )
 
@@ -30,8 +31,29 @@ type generateArgs struct {
 	namespace       string
 	svcPrefix       string
 
+	verbose    bool
 	checkReady bool
 	timeout    time.Duration
+}
+
+type generateResult struct {
+	ksvcGenerateSuccess int
+	ksvcGenerateFail    int
+	ksvcReady           int
+	ksvcNotReady        int
+	m                   sync.Mutex
+}
+
+func (g *generateResult) SetSuccess() {
+	g.m.Lock()
+	defer g.m.Unlock()
+	g.ksvcGenerateSuccess += 1
+}
+
+func (g *generateResult) SetFail() {
+	g.m.Lock()
+	defer g.m.Unlock()
+	g.ksvcGenerateFail += 1
 }
 
 type cleanArgs struct {
@@ -40,6 +62,25 @@ type cleanArgs struct {
 	namespace       string
 	svcPrefix       string
 	concurrency     int
+	verbose         bool
+}
+
+type cleanResult struct {
+	ksvcCleanSuccess int
+	ksvcCleanFail    int
+	m                sync.Mutex
+}
+
+func (c *cleanResult) SetSuccess() {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.ksvcCleanSuccess += 1
+}
+
+func (c *cleanResult) SetFail() {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.ksvcCleanFail += 1
 }
 
 type measureArgs struct {

--- a/pkg/command/service/measure.go
+++ b/pkg/command/service/measure.go
@@ -132,6 +132,12 @@ kperf service measure --svc-perfix svc --range 1,200 --namespace ns --concurrenc
 				}
 			}
 
+			var verbose = cmd.Flags().Changed("verbose")
+			if verbose {
+				fmt.Printf("[Verbose] Start to measure Knative services...\n")
+				fmt.Printf("[Verbose] Concurrency: %d\n", measureArgs.concurrency)
+			}
+
 			rows := make([][]string, 0)
 			rawRows := make([][]string, 0)
 
@@ -378,7 +384,7 @@ kperf service measure --svc-perfix svc --range 1,200 --namespace ns --concurrenc
 							ingressNetworkConfiguredTime.String(),
 							ingressLoadBalancerReadyTime.String()})
 
-						if cmd.Flags().Changed("verbose") {
+						if verbose {
 							fmt.Printf("[Verbose] Service %s: Service Configuration Ready Duration is %s/%fs\n",
 								svc, svcConfigurationsReadyDuration, svcConfigurationsReadyDuration.Seconds())
 							fmt.Printf("[Verbose] Service %s: - Service Revision Ready Duration is %s/%fs\n",
@@ -686,7 +692,7 @@ kperf service measure --svc-perfix svc --range 1,200 --namespace ns --concurrenc
 	serviceMeasureCommand.Flags().StringVarP(&measureArgs.svcRange, "range", "r", "", "Desired service range")
 	serviceMeasureCommand.Flags().StringVarP(&measureArgs.namespace, "namespace", "", "", "Service namespace")
 	serviceMeasureCommand.Flags().StringVarP(&measureArgs.svcPrefix, "svc-prefix", "", "", "Service name prefix")
-	serviceMeasureCommand.Flags().BoolVarP(&measureArgs.verbose, "verbose", "v", false, "Service verbose result")
+	serviceMeasureCommand.Flags().BoolVarP(&measureArgs.verbose, "verbose", "v", false, "Verbose output. The details of Knative Services measuring output")
 	serviceMeasureCommand.Flags().StringVarP(&measureArgs.namespaceRange, "namespace-range", "", "", "Service namespace range")
 	serviceMeasureCommand.Flags().StringVarP(&measureArgs.namespacePrefix, "namespace-prefix", "", "", "Service namespace prefix")
 	serviceMeasureCommand.Flags().IntVarP(&measureArgs.concurrency, "concurrency", "c", 10, "Number of workers to do measurement job")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->
Fix: https://github.com/knative-sandbox/kperf/issues/17

/kind enhancement

At this stage, --verbose flag was only be implemented in measurement, so this change add --verbose flag in generation and cleaning, and add some useful information for debugging purpose, such as arguments, result of service operations. 

Generate with --verbose flag:
```
./kperf service generate --namespace-prefix test --namespace-range 1,5 --svc-prefix ksvc -n 10 -b 2 -i 10 --verbose     
[Verbose] Start to generate Knative services...
[Verbose] Number: 10
[Verbose] Namespaces: [test-1 test-2 test-3 test-4 test-5]
[Verbose] Interval: 10
[Verbose] Batch: 2
[Verbose] Concurrency: 10
[Verbose] MinScale: 0
[Verbose] MaxScale: 0
[Verbose] Timeout: 600000000000
[Verbose] Wait for ready: false
Creating Knative Service ksvc-0 in namespace test-1
Creating Knative Service ksvc-1 in namespace test-2
Creating Knative Service ksvc-3 in namespace test-4
Creating Knative Service ksvc-2 in namespace test-3
Creating Knative Service ksvc-5 in namespace test-1
Creating Knative Service ksvc-4 in namespace test-5
Creating Knative Service ksvc-6 in namespace test-2
Creating Knative Service ksvc-7 in namespace test-3
Creating Knative Service ksvc-9 in namespace test-5
Creating Knative Service ksvc-8 in namespace test-4
[Verbose] Knative services generation finished.
[Verbose] Generated namespaces number: 5
[Verbose] Generated Knative services number, success: 10, fail: 0
```

Measure with --verbose flag:
```
./kperf service measure --namespace-prefix test --namespace-range 1,3 --svc-prefix ksvc --range 0,10 --verbose         
[Verbose] Start to measure Knative services...
[Verbose] Concurrency: 10
service ksvc-6/test-2 not ready and skip measuring
service ksvc-5/test-1 not ready and skip measuring
service ksvc-1/test-2 not ready and skip measuring
service ksvc-7/test-3 not ready and skip measuring
service ksvc-2/test-3 not ready and skip measuring
service ksvc-0/test-1 not ready and skip measuring
-----------------------------
Basic Information:
  - Knative Versions:
    Serving: 0.20.0
    Eventing: 0.20.0
  - Ingress Information:
    Controller: Istio
    Version: 1.7.3
Service Ready Measurement:
```

Clean with --verbose flag:
```
./kperf service clean --namespace-prefix test --namespace-range 1,5 --svc-prefix ksvc --verbose
[Verbose] Start to clean Knative services...
[Verbose] Concurrency: 10
Delete ksvc ksvc-0 in namespace test-1
Delete ksvc ksvc-1 in namespace test-2
Delete ksvc ksvc-5 in namespace test-1
Delete ksvc ksvc-2 in namespace test-3
Delete ksvc ksvc-6 in namespace test-2
Delete ksvc ksvc-7 in namespace test-3
Delete ksvc ksvc-3 in namespace test-4
Delete ksvc ksvc-9 in namespace test-5
Delete ksvc ksvc-4 in namespace test-5
Delete ksvc ksvc-8 in namespace test-4
[Verbose] Knative services cleaning finished.
[Verbose] Cleaned namespaces number: 10
[Verbose] Cleaned Knative services number, success: 10, fail: 0
```
