### PR TITLE
Adds docs for running `scale` with non-istio network

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,9 @@ Measurement saved in JSON file /tmp/20211108115231_ksvc_creation_time.json
 Visualized measurement saved in HTML file /tmp/20211108115231_ksvc_creation_time.html
 ```
 
-- By default, the `scale` command assumes you are using Istio as your networking layer. You can use an alternative networking layer by setting the `GATEWAY_OVERRIDE` and `GATEWAY_NAMESPACE_OVERRIDE` environmental variables. 
+- By default, the `scale` command assumes you are using Istio as your networking layer. You can use an alternative networking layer by setting the `GATEWAY_OVERRIDE` and `GATEWAY_NAMESPACE_OVERRIDE` environmental variables.
 
-For example, to run the `scale` command using Kourier, 
+For example, to run the `scale` command using Kourier,
 
 ``` bash
 GATEWAY_OVERRIDE=kourier GATEWAY_NAMESPACE_OVERRIDE=kourier-system kperf service scale  --namespace ktest --svc-prefix ktest --range 0,9  --verbose --output /tmp

--- a/README.md
+++ b/README.md
@@ -248,3 +248,11 @@ Measurement saved in CSV file /tmp/20211108115231_ksvc_creation_time.csv
 Measurement saved in JSON file /tmp/20211108115231_ksvc_creation_time.json
 Visualized measurement saved in HTML file /tmp/20211108115231_ksvc_creation_time.html
 ```
+
+- By default, the `scale` command assumes you are using Istio as your networking layer. You can use an alternative networking layer by setting the `GATEWAY_OVERRIDE` and `GATEWAY_NAMESPACE_OVERRIDE` environmental variables. 
+
+For example, to run the `scale` command using Kourier, 
+
+``` bash
+GATEWAY_OVERRIDE=kourier GATEWAY_NAMESPACE_OVERRIDE=kourier-system kperf service scale  --namespace ktest --svc-prefix ktest --range 0,9  --verbose --output /tmp
+```


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

Adds details in the README about how to use the gateway override environmental variables to run the `scale` command using a network layer other than Istio.

Fixes #211 