### PR TITLE
Cleanup vendor owners files after build

### DIFF
--- a/hack/build-funcs.sh
+++ b/hack/build-funcs.sh
@@ -93,3 +93,12 @@ function check_license() {
   fi
   rm $check_output
 }
+
+function build_cleanup() {
+  # Remove unwanted vendor files
+  find vendor/ \( -name "OWNERS" \
+    -o -name "OWNERS_ALIASES" \
+    -o -name "BUILD" \
+    -o -name "BUILD.bazel" \
+    -o -name "*_test.go" \) -exec rm -f {} +
+}

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -51,3 +51,4 @@ check_license
 go_fmt
 go_build
 go_test
+build_cleanup


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

<!-- Thanks for sending a pull request! -->

# Changes

Previously, running `./hack/build.sh` resulted in pulling in all the various `OWNERS` files into the vendor directory. As those files are not tracked in the repo (in fact, the build-deps script actively removes them), this PR adds a step to the build script to remove them.

/assign @maximilien 