### PR TITLE
Add option for using custom service

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -47,6 +47,8 @@ type GenerateArgs struct {
 
 	CheckReady bool
 	Timeout    time.Duration
+
+	Template string
 }
 
 type CleanArgs struct {


### PR DESCRIPTION
Signed-off-by: Paul S. Schweigert <paulschw@us.ibm.com>

# Changes

Fixes #67 

Adds a `--template` flag that lets KPerf runs its benchmarks against a custom service. The flag takes the location of a YAML file and will exit if a valid file is not provided or if it cannot parse the KService from said file.

/kind enhancement

/assign @maximilien 

**Release Note**

```release-note
Users can now select a custom KService to run with KPerf. If a valid YAML file is provided through the `--template` flag, KPerf will use it when running its benchmarks. For example, to use the `/home/user/test-service.yaml` file, one would run `kperf [other options] --template /home/user/test-service.yaml`
```
