### PR TITLE
add common functions to generate output and fix a bug

### DIFF
--- a/pkg/command/service/common.go
+++ b/pkg/command/service/common.go
@@ -150,7 +150,7 @@ func GetIngressController(p *pkg.PerfParams) map[string]string {
 	return ingressController
 }
 
-// GenerateJSONOutput generates CSV file from the rows data
+// GenerateCSVOutput generates CSV file from the rows data
 func GenerateCSVOutput(rows [][]string, outputPathPrefix string) (csvPath string, err error) {
 	csvPath = outputPathPrefix + ".csv"
 	err = utils.GenerateCSVFile(csvPath, rows)
@@ -209,15 +209,20 @@ func GenerateOutput(inputsOutput string, outputFilenameFlag string, csvFlag bool
 	if csvFlag && rows != nil {
 		// generate csv file from rows
 		csvPath, err := GenerateCSVOutput(rows, outputPathPrefix)
-		if err == nil {
-			fmt.Printf("Measurement saved in CSV file %s\n", csvPath)
+		if err != nil {
+			fmt.Printf("failed to save measurement in CSV file: %s\n", err)
+			return err
 		}
+		fmt.Printf("Measurement saved in CSV file %s\n", csvPath)
+
 		// generate html file from csv file
 		if htmlFlag && csvPath != "" {
 			htmlPath, err := GenerateHTMLOutput(csvPath, outputPathPrefix)
-			if err == nil {
-				fmt.Printf("Visualized measurement saved in HTML file %s\n", htmlPath)
+			if err != nil {
+				fmt.Printf("failed to save visualized measurement in HTML file: %s\n", err)
+				return err
 			}
+			fmt.Printf("Visualized measurement saved in HTML file %s\n", htmlPath)
 		}
 	} else if htmlFlag {
 		fmt.Printf("HTML output needs CSV output, please reset CSV Flag.\n")
@@ -225,9 +230,11 @@ func GenerateOutput(inputsOutput string, outputFilenameFlag string, csvFlag bool
 	if jsonFlag {
 		// generate json file from result
 		jsonPath, err := GenerateJSONOutput(result, outputPathPrefix)
-		if err == nil {
-			fmt.Printf("Measurement saved in JSON file %s\n", jsonPath)
+		if err != nil {
+			fmt.Printf("failed to save measurement in JSON file: %s\n", err)
+			return err
 		}
+		fmt.Printf("Measurement saved in JSON file %s\n", jsonPath)
 	}
 	return nil
 }
@@ -235,14 +242,14 @@ func GenerateOutput(inputsOutput string, outputFilenameFlag string, csvFlag bool
 // deleteFile deletes a file from the filepath
 func deleteFile(filepath string) error {
 	_, err := os.Stat(filepath)
-	if err == nil {
-		err := os.Remove(filepath)
-		if err != nil {
-			fmt.Printf("remove %s error : %s\n", filepath, err)
-			return err
-		}
-		return nil
+	if err != nil {
+		fmt.Printf("stat %s error : %s\n", filepath, err)
+		return err
 	}
-	fmt.Printf("stat %s error : %s\n", filepath, err)
-	return err
+	err = os.Remove(filepath)
+	if err != nil {
+		fmt.Printf("remove %s error : %s\n", filepath, err)
+		return err
+	}
+	return nil
 }

--- a/pkg/command/service/load.go
+++ b/pkg/command/service/load.go
@@ -16,13 +16,9 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"path/filepath"
-
-	"knative.dev/kperf/pkg/command/utils"
 
 	"log"
 	"os/exec"
@@ -133,36 +129,11 @@ func LoadServicesUpFromZero(params *pkg.PerfParams, inputs pkg.LoadArgs) error {
 	}
 	rows = append([][]string{row}, rows...)
 
-	current := time.Now()
-	outputLocation, err := utils.CheckOutputLocation(inputs.Output)
+	// generate CSV, HTML and JSON outputs from rows and loadFromZeroResult
+	err = GenerateOutput(inputs.Output, LoadOutputFilename, true, true, true, rows, loadFromZeroResult)
 	if err != nil {
-		fmt.Printf("failed to check measure output location: %s\n", err)
+		fmt.Printf("failed to generate output: %s\n", err)
 	}
-
-	csvPath := filepath.Join(outputLocation, fmt.Sprintf("%s_%s.csv", current.Format(DateFormatString), LoadOutputFilename))
-	err = utils.GenerateCSVFile(csvPath, rows)
-	if err != nil {
-		fmt.Printf("failed to generate CSV file and skip %s\n", err)
-	}
-	fmt.Printf("Measurement saved in CSV file %s\n", csvPath)
-
-	jsonPath := filepath.Join(outputLocation, fmt.Sprintf("%s_%s.json", current.Format(DateFormatString), LoadOutputFilename))
-	jsonData, err := json.Marshal(loadFromZeroResult)
-	if err != nil {
-		fmt.Printf("failed to generate json data and skip %s\n", err)
-	}
-	err = utils.GenerateJSONFile(jsonData, jsonPath)
-	if err != nil {
-		fmt.Printf("failed to generate json file and skip %s\n", err)
-	}
-	fmt.Printf("Measurement saved in JSON file %s\n", jsonPath)
-
-	htmlPath := filepath.Join(outputLocation, fmt.Sprintf("%s_%s.html", current.Format(DateFormatString), LoadOutputFilename))
-	err = utils.GenerateHTMLFile(csvPath, htmlPath)
-	if err != nil {
-		fmt.Printf("failed to generate HTML file and skip %s\n", err)
-	}
-	fmt.Printf("Visualized measurement saved in HTML file %s\n", htmlPath)
 
 	return nil
 }

--- a/pkg/command/service/load.go
+++ b/pkg/command/service/load.go
@@ -133,6 +133,7 @@ func LoadServicesUpFromZero(params *pkg.PerfParams, inputs pkg.LoadArgs) error {
 	err = GenerateOutput(inputs.Output, LoadOutputFilename, true, true, true, rows, loadFromZeroResult)
 	if err != nil {
 		fmt.Printf("failed to generate output: %s\n", err)
+		return err
 	}
 
 	return nil

--- a/pkg/command/service/measure.go
+++ b/pkg/command/service/measure.go
@@ -16,10 +16,8 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -39,11 +37,12 @@ import (
 	v1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"knative.dev/kperf/pkg"
-	"knative.dev/kperf/pkg/command/utils"
 )
 
 const (
-	DateFormatString = "20060102150405"
+	DateFormatString         = "20060102150405"
+	RawMeasureOutputFilename = "raw_ksvc_creation_time"
+	MeasureOutputFilename    = "ksvc_creation_time"
 )
 
 type MeasureServicesOptions struct {
@@ -659,42 +658,21 @@ func MeasureServices(params *pkg.PerfParams, inputs pkg.MeasureArgs, options Mea
 		measureFinalResult.Result.P99, _ = stats.Percentile(measureFinalResult.SvcReadyTime, 99)
 		fmt.Printf("Percentile99: %fs\n", measureFinalResult.Result.P99)
 
-		current := time.Now()
-		outputLocation, err := utils.CheckOutputLocation(inputs.Output)
+		// generate CSV output of raw timestamp from rawRows
+		rawOutputFilename, err := GenerateOutputPathPrefix(inputs.Output, RawMeasureOutputFilename)
 		if err != nil {
-			fmt.Printf("failed to check measure output location: %s\n", err)
+			fmt.Printf("failed to generate raw output filename: %s", err)
+			return err
 		}
-		rawPath := filepath.Join(outputLocation, fmt.Sprintf("%s_%s", current.Format(DateFormatString), "raw_ksvc_creation_time.csv"))
-		err = utils.GenerateCSVFile(rawPath, rawRows)
+		rawCSVPath, err := GenerateCSVOutput(rows, rawOutputFilename)
+		if err == nil {
+			fmt.Printf("Raw Timestamp saved in CSV file %s\n", rawCSVPath)
+		}
+		// generate CSV, HTML and JSON outputs from rows and measureFinalResult
+		err = GenerateOutput(inputs.Output, MeasureOutputFilename, true, true, true, rows, measureFinalResult)
 		if err != nil {
-			fmt.Printf("failed to generate raw timestamp file and skip %s\n", err)
+			fmt.Printf("failed to generate output: %s\n", err)
 		}
-		fmt.Printf("Raw Timestamp saved in CSV file %s\n", rawPath)
-
-		csvPath := filepath.Join(outputLocation, fmt.Sprintf("%s_%s", current.Format(DateFormatString), "ksvc_creation_time.csv"))
-		err = utils.GenerateCSVFile(csvPath, rows)
-		if err != nil {
-			fmt.Printf("failed to generate CSV file and skip %s\n", err)
-		}
-		fmt.Printf("Measurement saved in CSV file %s\n", csvPath)
-
-		jsonPath := filepath.Join(outputLocation, fmt.Sprintf("%s_%s", current.Format(DateFormatString), "ksvc_creation_time.json"))
-		jsonData, err := json.Marshal(measureFinalResult)
-		if err != nil {
-			fmt.Printf("failed to generate json data and skip %s\n", err)
-		}
-		err = utils.GenerateJSONFile(jsonData, jsonPath)
-		if err != nil {
-			fmt.Printf("failed to generate json file and skip %s\n", err)
-		}
-		fmt.Printf("Measurement saved in JSON file %s\n", jsonPath)
-
-		htmlPath := filepath.Join(outputLocation, fmt.Sprintf("%s_%s", current.Format(DateFormatString), "ksvc_creation_time.html"))
-		err = utils.GenerateHTMLFile(csvPath, htmlPath)
-		if err != nil {
-			fmt.Printf("failed to generate HTML file and skip %s\n", err)
-		}
-		fmt.Printf("Visualized measurement saved in HTML file %s\n", htmlPath)
 	} else {
 		fmt.Printf("-----------------------------\n")
 		fmt.Printf("Basic Information:\n")

--- a/pkg/command/service/measure.go
+++ b/pkg/command/service/measure.go
@@ -665,13 +665,17 @@ func MeasureServices(params *pkg.PerfParams, inputs pkg.MeasureArgs, options Mea
 			return err
 		}
 		rawCSVPath, err := GenerateCSVOutput(rows, rawOutputFilename)
-		if err == nil {
-			fmt.Printf("Raw Timestamp saved in CSV file %s\n", rawCSVPath)
+		if err != nil {
+			fmt.Printf("failed to save Raw Timestamp: %s\n", err)
+			return err
 		}
+		fmt.Printf("Raw Timestamp saved in CSV file %s\n", rawCSVPath)
+
 		// generate CSV, HTML and JSON outputs from rows and measureFinalResult
 		err = GenerateOutput(inputs.Output, MeasureOutputFilename, true, true, true, rows, measureFinalResult)
 		if err != nil {
 			fmt.Printf("failed to generate output: %s\n", err)
+			return err
 		}
 	} else {
 		fmt.Printf("-----------------------------\n")

--- a/pkg/command/service/scale.go
+++ b/pkg/command/service/scale.go
@@ -124,10 +124,12 @@ func ScaleServicesUpFromZero(params *pkg.PerfParams, inputs pkg.ScaleArgs) error
 	for _, m := range scaleFromZeroResult.Measurment {
 		rows = append(rows, []string{m.ServiceName, m.ServiceNamespace, fmt.Sprintf("%f", m.ServiceLatency), fmt.Sprintf("%f", m.DeploymentLatency)})
 	}
+
 	// generate CSV, HTML and JSON outputs from rows and scaleFromZeroResult
 	err = GenerateOutput(inputs.Output, OutputFilename, true, true, true, rows, scaleFromZeroResult)
 	if err != nil {
 		fmt.Printf("failed to generate output: %s\n", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- add common functions to generate output, replace output generating method in sacle, measure and load https://github.com/knative-sandbox/kperf/pull/234#discussion_r890407562
  - `GenerateCSVOutput` generates CSV file from the rows data 
  - `GenerateHTMLOutput` generates HTML file from CSV file
  - `GenerateJSONOutput` generates JSON output from the result
  - `GenerateOutputPathPrefix` generates the prefix of output path, which can be combined with a suffix name(.csv) to form a complete path
  - `GenerateOutput` generates outputs according to flags(csvFlag, htmlFlag and josnFlag) from rows and result
  - developer can use `GenerateOutput` by flags to generate multiple types output or just generate specified type output by using specfied function
- fix error name in `deleteFile` https://github.com/knative-sandbox/kperf/pull/246#discussion_r899759143

# Docs
part of logs in my test related common functions:
- for kperf measure
```bash
$ kperf service measure --namespace ktest --svc-prefix ktest --range 0,4  --verbose --output /tmp

Overall Service Ready Measurement:
Total: 5 | Ready: 5 (100.00%)  NotReady: 0 (0.00%)  NotFound: 0 (0.00%)  Fail: 0 (0.00%) 
Total: 47.000000s
Average: 9.400000s
Median: 9.000000s
Min: 9.000000s
Max: 10.000000s
Percentile50: 9.000000s
Percentile90: 10.000000s
Percentile95: 10.000000s
Percentile98: 10.000000s
Percentile99: 10.000000s
Raw Timestamp saved in CSV file /tmp/20220622123104_raw_ksvc_creation_time.csv
Measurement saved in CSV file /tmp/20220622123104_ksvc_creation_time.csv
Visualized measurement saved in HTML file /tmp/20220622123104_ksvc_creation_time.html
Measurement saved in JSON file /tmp/20220622123104_ksvc_creation_time.json
```
- for kperf scale
```bash
$ kperf service scale --namespace ktest --svc-prefix ktest --range 0,4  --verbose --output /tmp

result of scale for service ktest-3 is 7.861440, 0.254398 
result of scale for service ktest-0 is 7.870160, 0.035453 
result of scale for service ktest-2 is 7.865791, 0.178091 
result of scale for service ktest-1 is 8.158028, 0.061039 
result of scale for service ktest-4 is 9.405787, 0.803893 
Measurement saved in CSV file /tmp/20220622123227_ksvc_scaling_time.csv
Visualized measurement saved in HTML file /tmp/20220622123227_ksvc_scaling_time.html
Measurement saved in JSON file /tmp/20220622123227_ksvc_scaling_time.json
```

- for kperf load
```bash
$ kperf service load --namespace ktest --svc-prefix ktest --range 0,4 --load-tool wrk --load-duration 60s --load-concurrency 30 --verbose --output /tmp

---------------------------------------------------------------------------------
Measurement saved in CSV file /tmp/20220622123421_ksvc_loading_time.csv
Visualized measurement saved in HTML file /tmp/20220622123421_ksvc_loading_time.html
Measurement saved in JSON file /tmp/20220622123421_ksvc_loading_time.json
```