### PR TITLE
fix golint errors: error strings should not end with punctuation or a newline

### DIFF
--- a/pkg/command/service/common.go
+++ b/pkg/command/service/common.go
@@ -37,7 +37,7 @@ func GetNamespaces(ctx context.Context, params *pkg.PerfParams, namespace, names
 	if namespacePrefix != "" {
 		r := strings.Split(namespaceRange, ",")
 		if len(r) != 2 {
-			return nsNameList, fmt.Errorf("expected range like 1,500, given %s\n", namespaceRange)
+			return nsNameList, fmt.Errorf("expected range like 1,500, given %s", namespaceRange)
 		}
 		start, err := strconv.Atoi(r[0])
 		if err != nil {
@@ -52,7 +52,7 @@ func GetNamespaces(ctx context.Context, params *pkg.PerfParams, namespace, names
 				namespaceRangeMap[fmt.Sprintf("%s-%d", namespacePrefix, i)] = true
 			}
 		} else {
-			return nsNameList, fmt.Errorf("failed to parse namespace range %s\n", namespaceRange)
+			return nsNameList, fmt.Errorf("failed to parse namespace range %s", namespaceRange)
 		}
 	}
 

--- a/pkg/command/service/generate.go
+++ b/pkg/command/service/generate.go
@@ -109,7 +109,7 @@ func GenerateServices(params *pkg.PerfParams, inputs pkg.GenerateArgs) error {
 	} else if inputs.NamespacePrefix != "" {
 		r := strings.Split(inputs.NamespaceRange, ",")
 		if len(r) != 2 {
-			return fmt.Errorf("expected range like 1,500, given %s\n", inputs.NamespaceRange)
+			return fmt.Errorf("expected range like 1,500, given %s", inputs.NamespaceRange)
 		}
 		start, err := strconv.Atoi(r[0])
 		if err != nil {

--- a/pkg/command/service/measure.go
+++ b/pkg/command/service/measure.go
@@ -100,7 +100,7 @@ func MeasureServices(params *pkg.PerfParams, inputs pkg.MeasureArgs, options Mea
 	if options.NamespaceChanged {
 		r := strings.Split(inputs.SvcRange, ",")
 		if len(r) != 2 {
-			return fmt.Errorf("expected range like 1,500, given %s\n", inputs.SvcRange)
+			return fmt.Errorf("expected range like 1,500, given %s", inputs.SvcRange)
 		}
 
 		start, err := strconv.Atoi(r[0])
@@ -120,17 +120,17 @@ func MeasureServices(params *pkg.PerfParams, inputs pkg.MeasureArgs, options Mea
 
 	autoscalingClient, err := params.NewAutoscalingClient()
 	if err != nil {
-		return fmt.Errorf("failed to create autoscaling client%s\n", err)
+		return fmt.Errorf("failed to create autoscaling client %s", err)
 	}
 	servingClient, err := params.NewServingClient()
 	if err != nil {
-		return fmt.Errorf("failed to create serving client%s\n", err)
+		return fmt.Errorf("failed to create serving client %s", err)
 	}
 
 	if options.NamespaceRangeChanged && options.NamespacePrefixChanged {
 		r := strings.Split(inputs.NamespaceRange, ",")
 		if len(r) != 2 {
-			return fmt.Errorf("expected namespace-range like 1,500, given %s\n", inputs.NamespaceRange)
+			return fmt.Errorf("expected namespace-range like 1,500, given %s", inputs.NamespaceRange)
 		}
 
 		start, err := strconv.Atoi(r[0])
@@ -165,7 +165,7 @@ func MeasureServices(params *pkg.PerfParams, inputs pkg.MeasureArgs, options Mea
 
 	nwclient, err := params.NewNetworkingClient()
 	if err != nil {
-		return fmt.Errorf("failed to create networking client%s\n", err)
+		return fmt.Errorf("failed to create networking client %s", err)
 	}
 
 	svcChannel := make(chan []string)

--- a/pkg/command/utils/util.go
+++ b/pkg/command/utils/util.go
@@ -25,7 +25,7 @@ import (
 func GenerateCSVFile(path string, rows [][]string) error {
 	file, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("failed to create csv file %s\n", err)
+		return fmt.Errorf("failed to create csv file %s", err)
 	}
 	defer file.Close()
 
@@ -77,16 +77,15 @@ func CheckOutputLocation(outputLocation string) (string, error) {
 	dirInfo, err := os.Stat(outputLocation)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return outputLocation, fmt.Errorf("output location (%s) is not existed: %s\n", outputLocation, err)
-		} else {
-			return outputLocation, fmt.Errorf("output location (%s) has error: %s\n", outputLocation, err)
+			return outputLocation, fmt.Errorf("output location (%s) is not existed: %s", outputLocation, err)
 		}
+		return outputLocation, fmt.Errorf("output location (%s) has error: %s", outputLocation, err)
 	} else {
 		if !dirInfo.IsDir() {
-			return outputLocation, fmt.Errorf("output location (%s) is not directory, please check!\n", outputLocation)
+			return outputLocation, fmt.Errorf("output location (%s) is not directory", outputLocation)
 		}
 		if dirInfo.Mode().Perm()&(1<<(uint(7))) == 0 {
-			return outputLocation, fmt.Errorf("output location (%s) is not writable, please check!\n", outputLocation)
+			return outputLocation, fmt.Errorf("output location (%s) is not writable", outputLocation)
 		}
 	}
 	return outputLocation, nil


### PR DESCRIPTION
# Changes
- :broom: fix golint errors 'error strings should not end with punctuation or a newline'