### PR TITLE
Support config file on service load

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -340,6 +340,82 @@ $ kperf service generate -n 5 -b 1 -c 1 -i 1 --namespace ktest --svc-prefix ktes
 
 2. Scale up services(ktest-0, ... , ktest-4) in namespace ktest with **wrk** using 30 workers and lasting for 60 seconds, and measure the scale up latency
 
+- Use config file to specify flags(refer to [Generate deployment load](#Generate-knative-service-deployment-load))
+  - `namespace`, `namespace-prefix`, `namespace-range`, `svc-prefix`, `range`, `output` are default **common flags** of all service subcommands
+  - Procedure of common flag in config
+    - Common flag specified in subcommand(such as `load.namespace`)  > common flag specified in parent command(such as `service.namespace`)
+
+```yaml
+# create config file
+service:
+  namespace: ktest
+  svc-prefix: ktest
+  range: 0,4
+  output: /tmp
+  generate:
+    batch: 5
+    interval: 1
+    number: 5
+  load:
+    load-concurrency: 30
+    load-duration: 60s
+    verbose: true
+```
+
+```bash
+$ kperf service load
+2022/08/09 09:55:37 Namespace ktest, Service ktest-1, load start
+2022/08/09 09:55:37 Namespace ktest, Service ktest-3, load start
+2022/08/09 09:55:37 Namespace ktest, Service ktest-4, load start
+2022/08/09 09:55:37 Namespace ktest, Service ktest-0, load start
+2022/08/09 09:55:37 Namespace ktest, Service ktest-2, load start
+2022/08/09 09:56:37 Namespace ktest, Service ktest-1, load end, take off 60.003 seconds
+2022/08/09 09:56:37 Namespace ktest, Service ktest-3, load end, take off 60.004 seconds
+2022/08/09 09:56:37 Namespace ktest, Service ktest-4, load end, take off 60.003 seconds
+2022/08/09 09:56:37 Namespace ktest, Service ktest-0, load end, take off 60.003 seconds
+2022/08/09 09:56:37 Namespace ktest, Service ktest-2, load end, take off 60.003 seconds
+...
+
+[Verbose] Namespace ktest, Service ktest-2:
+
+[Verbose] Load tool(default) output:
+Requests      [total, rate, throughput]         480, 0.00, 0.00
+Duration      [total, attack, wait]             0s, 0s, 0s
+Latencies     [min, mean, 50, 90, 95, 99, max]  1.55ms, 0s, 0s, 0s, 0s, 0s, 8.027s
+Bytes In      [total, mean]                     6240, 0.00
+Bytes Out     [total, mean]                     0, 0.00
+Success       [ratio]                           0.00%
+Status Codes  [code:count]                      200:480
+Error Set:
+
+[Verbose] Deployment replicas changed from 0 to 7:
+replicas        ready_duration(seconds)
+       0                          9.543
+       1                         15.961
+       2                         18.533
+       3                         20.946
+       4                         21.733
+       5                         24.531
+       6                         25.733
+
+[Verbose] Pods changed from 0 to 7:
+pods    ready_duration(seconds)
+   0                        4.0
+   1                        3.0
+   2                        3.0
+   3                        5.0
+   4                        5.0
+   5                        5.0
+   6                        4.0
+
+---------------------------------------------------------------------------------
+Measurement saved in CSV file /tmp/20220809095647_ksvc_loading_time.csv
+Visualized measurement saved in HTML file /tmp/20220809095647_ksvc_loading_time.html
+Measurement saved in JSON file /tmp/20220809095647_ksvc_loading_time.json
+```
+
+- Use command to specify flags
+
 ```bash
 $ kperf service load --namespace ktest --svc-prefix ktest --range 0,4 --load-tool wrk --load-duration 60s --load-concurrency 30 --verbose --output /tmp
 2022/06/01 08:36:52 Namespace ktest, Service ktest-4, load start

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -352,10 +352,6 @@ service:
   svc-prefix: ktest
   range: 0,4
   output: /tmp
-  generate:
-    batch: 5
-    interval: 1
-    number: 5
   load:
     load-concurrency: 30
     load-duration: 60s

--- a/pkg/command/service/generate.go
+++ b/pkg/command/service/generate.go
@@ -200,7 +200,7 @@ func GenerateServices(params *pkg.PerfParams, inputs pkg.GenerateArgs) error {
 			}
 		}
 		fmt.Printf("Error: Knative Service %s in namespace %s is not ready after %s\n", name, ns, inputs.Timeout)
-		return fmt.Errorf("Knative Service %s in namespace %s is not ready after %s ", name, ns, inputs.Timeout)
+		return fmt.Errorf("Knative Service %s in namespace %s is not ready after %s", name, ns, inputs.Timeout)
 
 	}
 	if inputs.CheckReady {

--- a/pkg/command/service/generate.go
+++ b/pkg/command/service/generate.go
@@ -200,7 +200,7 @@ func GenerateServices(params *pkg.PerfParams, inputs pkg.GenerateArgs) error {
 			}
 		}
 		fmt.Printf("Error: Knative Service %s in namespace %s is not ready after %s\n", name, ns, inputs.Timeout)
-		return fmt.Errorf("Knative Service %s in namespace %s is not ready after %s", name, ns, inputs.Timeout)
+		return fmt.Errorf("Knative Service %s in namespace %s is not ready after %s ", name, ns, inputs.Timeout)
 
 	}
 	if inputs.CheckReady {

--- a/pkg/command/service/generate_test.go
+++ b/pkg/command/service/generate_test.go
@@ -45,10 +45,16 @@ func TestNewServiceGenerateCommand(t *testing.T) {
 		cmd := NewServiceGenerateCommand(p)
 
 		_, err := testutil.ExecuteCommand(cmd)
-		assert.ErrorContains(t, err, "required flag(s) \"batch\", \"interval\", \"number\"")
+		assert.ErrorContains(t, err, "required flag(s)")
+		assert.ErrorContains(t, err, "batch")
+		assert.ErrorContains(t, err, "interval")
+		assert.ErrorContains(t, err, "number")
 
 		_, err = testutil.ExecuteCommand(cmd, "-b", "1")
-		assert.ErrorContains(t, err, "required flag(s) \"interval\", \"number\"")
+		// assert.ErrorContains(t, err, "required flag(s) \"interval\", \"number\"")
+		assert.ErrorContains(t, err, "required flag(s)")
+		assert.ErrorContains(t, err, "interval")
+		assert.ErrorContains(t, err, "number")
 
 		_, err = testutil.ExecuteCommand(cmd, "-b", "1", "-i", "1")
 		assert.ErrorContains(t, err, "required flag(s) \"number\"")

--- a/pkg/command/service/generate_test.go
+++ b/pkg/command/service/generate_test.go
@@ -50,7 +50,6 @@ func TestNewServiceGenerateCommand(t *testing.T) {
 		assert.ErrorContains(t, err, "number")
 
 		_, err = testutil.ExecuteCommand(cmd, "-b", "1")
-		// assert.ErrorContains(t, err, "required flag(s) \"interval\", \"number\"")
 		assert.ErrorContains(t, err, "required flag(s)")
 		assert.ErrorContains(t, err, "interval")
 		assert.ErrorContains(t, err, "number")

--- a/pkg/command/service/generate_test.go
+++ b/pkg/command/service/generate_test.go
@@ -43,7 +43,6 @@ func TestNewServiceGenerateCommand(t *testing.T) {
 			NewServingClient: servingClient,
 		}
 		cmd := NewServiceGenerateCommand(p)
-
 		_, err := testutil.ExecuteCommand(cmd)
 		assert.ErrorContains(t, err, "required flag(s)")
 		assert.ErrorContains(t, err, "batch")

--- a/pkg/command/service/load.go
+++ b/pkg/command/service/load.go
@@ -68,16 +68,22 @@ kperf service load --namespace ktest --svc-prefix ktest --range 0,3 --load-tool 
 			if err != nil {
 				return err
 			}
-			if cmd.Flags().NFlag() == 0 {
-				return fmt.Errorf("'service load' requires flag(s)")
-			}
+			// t := reflect.TypeOf(loadArgs)
+			// value := reflect.ValueOf(loadArgs)
+			// for i := 0; i < value.NumField(); i++ {
+			// 	fmt.Println(t.Field(i).Name, ": ", value.Field(i).Interface())
+			// }
+
+			// if cmd.Flags().NFlag() == 0 {
+			// 	return fmt.Errorf("'service load' requires flag(s)")
+			// }
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			t := reflect.TypeOf(loadArgs)
 			value := reflect.ValueOf(loadArgs)
 			for i := 0; i < value.NumField(); i++ {
-				log.Println(t.Field(i).Name, ": ", value.Field(i).Interface())
+				fmt.Println(t.Field(i).Name, ": ", value.Field(i).Interface())
 			}
 			return LoadServicesUpFromZero(p, loadArgs)
 		},
@@ -90,7 +96,7 @@ kperf service load --namespace ktest --svc-prefix ktest --range 0,3 --load-tool 
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.SvcRange, "range", "r", "", "Desired service range")
 	serviceLoadCommand.Flags().BoolVarP(&loadArgs.Verbose, "verbose", "v", false, "Service verbose result")
 	serviceLoadCommand.Flags().BoolVarP(&loadArgs.ResolvableDomain, "resolvable", "", false, "If Service endpoint resolvable url")
-	serviceLoadCommand.Flags().DurationVarP(&loadArgs.WaitPodsReadyDuration, "wait-time", "w", 10*time.Second, "Time to wait for all pods to be ready")
+	serviceLoadCommand.Flags().DurationVarP(&loadArgs.WaitPodsReadyDuration, "wait-time", "", 10*time.Second, "Time to wait for all pods to be ready")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.LoadTool, "load-tool", "t", "default", "Select the load test tool, use internal load test tool(vegeta) by default, also support external load tool(wrk and hey, require preinstallation)")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.LoadConcurrency, "load-concurrency", "c", "30", "total number of workers to run concurrently for the load test tool")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.LoadDuration, "load-duration", "d", "60s", "Duration of the test for the load test tool")
@@ -250,7 +256,7 @@ func runLoadFromZero(ctx context.Context, params *pkg.PerfParams, inputs pkg.Loa
 		loadDuration := loadEnd.Sub(loadStart)
 		log.Printf("Namespace %s, Service %s, load end, take off %.3f seconds\n", namespace, svc.Name, loadDuration.Seconds())
 
-		time.Sleep(inputs.WaitPodsReadyDuration * time.Second) //wait for all pods ready
+		time.Sleep(inputs.WaitPodsReadyDuration) //wait for all pods ready
 		pdch <- struct{}{}
 	}()
 

--- a/pkg/command/service/load.go
+++ b/pkg/command/service/load.go
@@ -25,7 +25,6 @@ import (
 
 	"log"
 	"os/exec"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -68,23 +67,9 @@ kperf service load --namespace ktest --svc-prefix ktest --range 0,3 --load-tool 
 			if err != nil {
 				return err
 			}
-			// t := reflect.TypeOf(loadArgs)
-			// value := reflect.ValueOf(loadArgs)
-			// for i := 0; i < value.NumField(); i++ {
-			// 	fmt.Println(t.Field(i).Name, ": ", value.Field(i).Interface())
-			// }
-
-			// if cmd.Flags().NFlag() == 0 {
-			// 	return fmt.Errorf("'service load' requires flag(s)")
-			// }
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			t := reflect.TypeOf(loadArgs)
-			value := reflect.ValueOf(loadArgs)
-			for i := 0; i < value.NumField(); i++ {
-				fmt.Println(t.Field(i).Name, ": ", value.Field(i).Interface())
-			}
 			return LoadServicesUpFromZero(p, loadArgs)
 		},
 	}
@@ -96,7 +81,7 @@ kperf service load --namespace ktest --svc-prefix ktest --range 0,3 --load-tool 
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.SvcRange, "range", "r", "", "Desired service range")
 	serviceLoadCommand.Flags().BoolVarP(&loadArgs.Verbose, "verbose", "v", false, "Service verbose result")
 	serviceLoadCommand.Flags().BoolVarP(&loadArgs.ResolvableDomain, "resolvable", "", false, "If Service endpoint resolvable url")
-	serviceLoadCommand.Flags().DurationVarP(&loadArgs.WaitPodsReadyDuration, "wait-time", "", 10*time.Second, "Time to wait for all pods to be ready")
+	serviceLoadCommand.Flags().DurationVarP(&loadArgs.WaitPodsReadyDuration, "wait-time", "w", 10*time.Second, "Time to wait for all pods to be ready")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.LoadTool, "load-tool", "t", "default", "Select the load test tool, use internal load test tool(vegeta) by default, also support external load tool(wrk and hey, require preinstallation)")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.LoadConcurrency, "load-concurrency", "c", "30", "total number of workers to run concurrently for the load test tool")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.LoadDuration, "load-duration", "d", "60s", "Duration of the test for the load test tool")

--- a/pkg/command/service/load.go
+++ b/pkg/command/service/load.go
@@ -25,6 +25,7 @@ import (
 
 	"log"
 	"os/exec"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -42,6 +43,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 
 	"knative.dev/kperf/pkg"
+	"knative.dev/kperf/pkg/config"
 	"knative.dev/serving/pkg/apis/serving"
 	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingv1client "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
@@ -62,12 +64,20 @@ For example:
 # To measure a Knative Service scaling from zero to N
 kperf service load --namespace ktest --svc-prefix ktest --range 0,3 --load-tool wrk --load-duration 60s --load-concurrency 40 --verbose --output /tmp`,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			err := config.BindFlags(cmd, "service.load.", nil)
+			if err != nil {
+				return err
+			}
 			if cmd.Flags().NFlag() == 0 {
 				return fmt.Errorf("'service load' requires flag(s)")
 			}
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			value := reflect.ValueOf(loadArgs)
+			for i := 0; i < value.NumField(); i++ {
+				log.Println(i, "=", value.Field(i))
+			}
 			return LoadServicesUpFromZero(p, loadArgs)
 		},
 	}

--- a/pkg/command/service/load.go
+++ b/pkg/command/service/load.go
@@ -74,9 +74,10 @@ kperf service load --namespace ktest --svc-prefix ktest --range 0,3 --load-tool 
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			t := reflect.TypeOf(loadArgs)
 			value := reflect.ValueOf(loadArgs)
 			for i := 0; i < value.NumField(); i++ {
-				log.Println(i, "=", value.Field(i))
+				log.Println(t.Field(i).Name, ": ", value.Field(i).Interface())
 			}
 			return LoadServicesUpFromZero(p, loadArgs)
 		},

--- a/pkg/command/service/load_test.go
+++ b/pkg/command/service/load_test.go
@@ -91,7 +91,7 @@ func TestNewServiceLoadCommand(t *testing.T) {
 	t.Run("uncompleted or wrong args for service load", func(t *testing.T) {
 		cmd := NewServiceLoadCommand(p)
 		_, err := testutil.ExecuteCommand(cmd)
-		assert.ErrorContains(t, err, "'service load' requires flag(s)")
+		assert.ErrorContains(t, err, "both namespace and namespace-prefix are empty")
 
 		_, err = testutil.ExecuteCommand(cmd, "--namespace-prefix", FakeNamespace, "--namespace-range", "1200")
 		assert.ErrorContains(t, err, "expected range like 1,500, given 1200")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -167,7 +167,7 @@ func BindFlags(cmd *cobra.Command, configPrefix string, set map[string]bool) (er
 				if err != nil {
 					return
 				}
-			} else {
+			} else if set != nil {
 				// Validate required flags
 				if set[f.Name] {
 					set[f.Name] = false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -196,7 +196,7 @@ func setFlagFromConfig(flagSet *pflag.FlagSet, f *pflag.Flag, prefix string, set
 	configPrefixName := prefix + f.Name
 
 	var val interface{}
-	// Precedure: flag value found by prefix from config > flag value found by parent prefix(common) from config
+	// Procedure: flag value found by prefix from config > flag value found by parent prefix(common) from config
 	if viper.IsSet(configPrefixName) { // flag value found by prefix from config
 		val = viper.Get(configPrefixName)
 	} else if commonFlags[parentCommand][f.Name] && viper.IsSet(parentPrefixName) { // common flag value found by parent prefix(common) from config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -189,7 +189,7 @@ func initCommonConfig() map[string]map[string]bool {
 	return common
 }
 
-// setFlagsByConfig applies viper config value to flag when flag is not set in command and config has a value
+// setFlagFromConfig applies viper config value to flag when flag is not set in command and config has a value
 func setFlagFromConfig(flagSet *pflag.FlagSet, f *pflag.Flag, prefix string, set map[string]bool) error {
 	parentCommand := strings.Split(prefix, ".")[0]
 	parentPrefixName := parentCommand + "." + f.Name


### PR DESCRIPTION
# Changes

- Supported config file on service load command
- Supported common flags in all subcommands of service 
  -  `namespace`, `namespace-prefix`, `namespace-range`, `svc-prefix`, `range`, `output` are default **common flags** of all service subcommands
  - Procedure of common flag in config
    - Common flag specified in subcommand(such as `load.namespace`)  > common flag specified in parent command(such as `service.namespace`)

- Improved `bindFlags()` of config.go, extracted complicated codes to `setFlagFromConfig()` and `validateRequiredFlags()`
- Updated docs of changes(more detailed docs of config, common flag and pipeline will be update after using these features to all subcommands)

Fixes #267 

**Docs**

test:

- config file

```docs
service:
  namespace: ktest
  svc-prefix: ktest
  range: 0,4
  output: /tmp
  generate:
    batch: 5
    interval: 1
    number: 5
  load:
    load-concurrency: 30
    load-duration: 60s
    verbose: true
```

- test result

```docs
$ kperf service generate
Creating Knative Service ktest-1 in namespace ktest
Creating Knative Service ktest-4 in namespace ktest
Creating Knative Service ktest-0 in namespace ktest
Creating Knative Service ktest-2 in namespace ktest
Creating Knative Service ktest-3 in namespace ktest

$ kperf service load
2022/08/09 09:55:37 Namespace ktest, Service ktest-1, load start
2022/08/09 09:55:37 Namespace ktest, Service ktest-3, load start
2022/08/09 09:55:37 Namespace ktest, Service ktest-4, load start
2022/08/09 09:55:37 Namespace ktest, Service ktest-0, load start
2022/08/09 09:55:37 Namespace ktest, Service ktest-2, load start
2022/08/09 09:56:37 Namespace ktest, Service ktest-1, load end, take off 60.003 seconds
2022/08/09 09:56:37 Namespace ktest, Service ktest-3, load end, take off 60.004 seconds
2022/08/09 09:56:37 Namespace ktest, Service ktest-4, load end, take off 60.003 seconds
2022/08/09 09:56:37 Namespace ktest, Service ktest-0, load end, take off 60.003 seconds
2022/08/09 09:56:37 Namespace ktest, Service ktest-2, load end, take off 60.003 seconds
...

[Verbose] Namespace ktest, Service ktest-2:

[Verbose] Load tool(default) output:
Requests      [total, rate, throughput]         480, 0.00, 0.00
Duration      [total, attack, wait]             0s, 0s, 0s
Latencies     [min, mean, 50, 90, 95, 99, max]  1.55ms, 0s, 0s, 0s, 0s, 0s, 8.027s
Bytes In      [total, mean]                     6240, 0.00
Bytes Out     [total, mean]                     0, 0.00
Success       [ratio]                           0.00%
Status Codes  [code:count]                      200:480
Error Set:

[Verbose] Deployment replicas changed from 0 to 7:
replicas        ready_duration(seconds)
       0                          9.543
       1                         15.961
       2                         18.533
       3                         20.946
       4                         21.733
       5                         24.531
       6                         25.733

[Verbose] Pods changed from 0 to 7:
pods    ready_duration(seconds)
   0                        4.0
   1                        3.0
   2                        3.0
   3                        5.0
   4                        5.0
   5                        5.0
   6                        4.0

---------------------------------------------------------------------------------
Measurement saved in CSV file /tmp/20220809095647_ksvc_loading_time.csv
Visualized measurement saved in HTML file /tmp/20220809095647_ksvc_loading_time.html
Measurement saved in JSON file /tmp/20220809095647_ksvc_loading_time.json
```