### PR TITLE
fix bug in verifing external ip existence of loadbalancer

### DIFF
--- a/pkg/command/service/scale.go
+++ b/pkg/command/service/scale.go
@@ -317,8 +317,8 @@ func getIngressEndpoint(ctx context.Context, params *pkg.PerfParams) (address st
 	}
 
 	var endpoint string
-	// If the ExternalIP of istio-ingressgateway is none or pending, get endpoint with node port
-	if len(ingress.Spec.ExternalIPs) == 0 {
+	// If the ExternalIP of LoadBalancer is none or pending, get endpoint with node port
+	if len(ingress.Status.LoadBalancer.Ingress) == 0 {
 		endpoint, err = endpointWithNodePortFromService(ingress, ctx, params)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes
- :bug: fix the verify method of external ip existence of loadbalancer

example of a loadbalancer with external ip(istio-ingressgatway)
```bash
$ kubectl get svc istio-ingressgateway -n istio-system
NAME                   TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)                                      AGE
istio-ingressgateway   LoadBalancer   10.96.234.32   172.100.10.10   15021:32715/TCP,80:32706/TCP,443:32144/TCP   14d
```

```yaml
$ k get svc istio-ingressgateway -n istio-system -o yaml
apiVersion: v1
kind: Service
metadata:
  ...
spec:
  allocateLoadBalancerNodePorts: true
  clusterIP: 10.96.234.32
  clusterIPs:
  - 10.96.234.32
  externalTrafficPolicy: Cluster
  internalTrafficPolicy: Cluster
  ipFamilies:
  - IPv4
  ipFamilyPolicy: SingleStack
  ports:
  - name: status-port
    nodePort: 32715
    port: 15021
    protocol: TCP
    targetPort: 15021
  - name: http2
    nodePort: 32706
    port: 80
    protocol: TCP
    targetPort: 8080
  - name: https
    nodePort: 32144
    port: 443
    protocol: TCP
    targetPort: 8443
  selector:
    app: istio-ingressgateway
    istio: ingressgateway
  sessionAffinity: None

 status:
# if external ip is pending
# loadBalancer: {}
# if external ip is configured
  loadBalancer:
      ingress:
      - ip: 172.100.10.10
```