### PR TITLE
Fix svc-range invalid bug and support specified svc in load and scale command

### DIFF
--- a/pkg/command/service/common.go
+++ b/pkg/command/service/common.go
@@ -29,7 +29,14 @@ import (
 
 	"knative.dev/kperf/pkg"
 	"knative.dev/kperf/pkg/command/utils"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
+	servingv1client "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 )
+
+type ServicesToScale struct {
+	Namespace string
+	Service   *servingv1.Service
+}
 
 func GetNamespaces(ctx context.Context, params *pkg.PerfParams, namespace, namespaceRange, namespacePrefix string) ([]string, error) {
 	nsNameList := []string{}
@@ -91,6 +98,73 @@ func GetNamespaces(ctx context.Context, params *pkg.PerfParams, namespace, names
 		return nsNameList, errors.New("both namespace and namespace-prefix are empty")
 	}
 	return nsNameList, nil
+}
+
+// getServices gets existed services by svc or (svc-prefix, svcRange)
+func getServices(ctx context.Context, servingClient servingv1client.ServingV1Interface, nsNameList []string, service string, svcPrefix string, svcRange string) ([]ServicesToScale, error) {
+	objs := []ServicesToScale{}
+	// generate a svcRange map by svcPrefix and svcRange
+	var svcRangeMap map[string]bool = map[string]bool{}
+	if svcPrefix != "" && svcRange != "" {
+		r := strings.Split(svcRange, ",")
+		if len(r) != 2 {
+			return objs, fmt.Errorf("expected svc range like 1,500, given %s", svcRange)
+		}
+		start, err := strconv.Atoi(r[0])
+		if err != nil {
+			return objs, err
+		}
+		end, err := strconv.Atoi(r[1])
+		if err != nil {
+			return objs, err
+		}
+		if start >= 0 && end >= 0 && start <= end {
+			for i := start; i <= end; i++ {
+				svcRangeMap[fmt.Sprintf("%s-%d", svcPrefix, i)] = true
+			}
+		} else {
+			return objs, fmt.Errorf("failed to parse namespace range %s", svcRange)
+		}
+	}
+	if service != "" { // get existed service by given svc name
+		for _, ns := range nsNameList {
+			svc, err := servingClient.Services(ns).Get(ctx, service, metav1.GetOptions{})
+			if err != nil {
+				return objs, err
+			}
+			objs = append(objs, ServicesToScale{Namespace: ns, Service: svc})
+		}
+		if len(objs) == 0 {
+			return objs, fmt.Errorf("svc with name %s not found", service)
+		}
+	} else if svcPrefix != "" { // get existed services by svcRangeMap and svcPrefix in nsNameList
+		for _, ns := range nsNameList {
+			svcList, err := servingClient.Services(ns).List(ctx, metav1.ListOptions{})
+			if err == nil {
+				if len(svcRangeMap) >= 0 { // get existed services in svcRangeMap
+					for _, s := range svcList.Items {
+						svc := s
+						if _, exists := svcRangeMap[svc.Name]; exists {
+							objs = append(objs, ServicesToScale{Namespace: ns, Service: &svc})
+						}
+					}
+				} else { // get existed services by svcPrefix if svcRangeMap is empty
+					for _, s := range svcList.Items {
+						svc := s
+						if strings.HasPrefix(s.Name, svcPrefix) {
+							objs = append(objs, ServicesToScale{Namespace: ns, Service: &svc})
+						}
+					}
+				}
+			}
+		}
+		if len(objs) == 0 {
+			return objs, fmt.Errorf("no ksvc found with prefix %s", svcPrefix)
+		}
+	} else {
+		return objs, errors.New("both svc and svc-prefix are empty")
+	}
+	return objs, nil
 }
 
 // Get Knative Serving and Eventing version

--- a/pkg/command/service/common.go
+++ b/pkg/command/service/common.go
@@ -101,7 +101,7 @@ func GetNamespaces(ctx context.Context, params *pkg.PerfParams, namespace, names
 }
 
 // getServices gets existed services by svc or (svc-prefix, svcRange)
-func getServices(ctx context.Context, servingClient servingv1client.ServingV1Interface, nsNameList []string, service string, svcPrefix string, svcRange string) ([]ServicesToScale, error) {
+func getServices(ctx context.Context, servingClient servingv1client.ServingV1Interface, nsNameList []string, svcPrefix string, svcRange string, service string) ([]ServicesToScale, error) {
 	objs := []ServicesToScale{}
 	// generate a svcRange map by svcPrefix and svcRange
 	var svcRangeMap map[string]bool = map[string]bool{}
@@ -123,7 +123,7 @@ func getServices(ctx context.Context, servingClient servingv1client.ServingV1Int
 				svcRangeMap[fmt.Sprintf("%s-%d", svcPrefix, i)] = true
 			}
 		} else {
-			return objs, fmt.Errorf("failed to parse namespace range %s", svcRange)
+			return objs, fmt.Errorf("failed to parse svc range %s", svcRange)
 		}
 	}
 	if service != "" { // get existed service by given svc name
@@ -132,7 +132,9 @@ func getServices(ctx context.Context, servingClient servingv1client.ServingV1Int
 			if err != nil {
 				return objs, err
 			}
-			objs = append(objs, ServicesToScale{Namespace: ns, Service: svc})
+			if service == svc.Name {
+				objs = append(objs, ServicesToScale{Namespace: ns, Service: svc})
+			}
 		}
 		if len(objs) == 0 {
 			return objs, fmt.Errorf("svc with name %s not found", service)

--- a/pkg/command/service/load.go
+++ b/pkg/command/service/load.go
@@ -77,6 +77,7 @@ kperf service load --namespace ktest --svc-prefix ktest --range 0,3 --load-tool 
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.Namespace, "namespace", "", "", "Service namespace")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.NamespaceRange, "namespace-range", "", "", "Service namespace range")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.NamespacePrefix, "namespace-prefix", "", "", "Service namespace prefix")
+	serviceLoadCommand.Flags().StringVarP(&loadArgs.Svc, "svc", "", "", "Service name")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.SvcPrefix, "svc-prefix", "", "", "Service name prefix")
 	serviceLoadCommand.Flags().StringVarP(&loadArgs.SvcRange, "range", "r", "", "Desired service range")
 	serviceLoadCommand.Flags().BoolVarP(&loadArgs.Verbose, "verbose", "v", false, "Service verbose result")
@@ -150,7 +151,7 @@ func loadAndMeasure(ctx context.Context, params *pkg.PerfParams, inputs pkg.Load
 	if err != nil {
 		return result, err
 	}
-	objs, err := servicesListFunc(ctx, ksvcClient, nsNameList, inputs.Svc, inputs.SvcPrefix, inputs.SvcRange)
+	objs, err := servicesListFunc(ctx, ksvcClient, nsNameList, inputs.SvcPrefix, inputs.SvcRange, inputs.Svc)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/command/service/load.go
+++ b/pkg/command/service/load.go
@@ -144,13 +144,16 @@ func LoadServicesUpFromZero(params *pkg.PerfParams, inputs pkg.LoadArgs) error {
 	return nil
 }
 
-func loadAndMeasure(ctx context.Context, params *pkg.PerfParams, inputs pkg.LoadArgs, nsNameList []string, servicesListFunc func(context.Context, servingv1client.ServingV1Interface, []string, string) []ServicesToScale) (pkg.LoadResult, error) {
+func loadAndMeasure(ctx context.Context, params *pkg.PerfParams, inputs pkg.LoadArgs, nsNameList []string, servicesListFunc func(context.Context, servingv1client.ServingV1Interface, []string, string, string, string) ([]ServicesToScale, error)) (pkg.LoadResult, error) {
 	result := pkg.LoadResult{}
 	ksvcClient, err := params.NewServingClient()
 	if err != nil {
 		return result, err
 	}
-	objs := servicesListFunc(ctx, ksvcClient, nsNameList, inputs.SvcPrefix)
+	objs, err := servicesListFunc(ctx, ksvcClient, nsNameList, inputs.Svc, inputs.SvcPrefix, inputs.SvcRange)
+	if err != nil {
+		return result, err
+	}
 	count := len(objs)
 
 	var wg sync.WaitGroup

--- a/pkg/command/service/load_test.go
+++ b/pkg/command/service/load_test.go
@@ -65,13 +65,7 @@ func TestNewServiceLoadCommand(t *testing.T) {
 			Name: FakeNamespace,
 		},
 	}
-	svc := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      FakeServiceName,
-			Namespace: FakeNamespace,
-		},
-	}
-	client := k8sfake.NewSimpleClientset(ns, &svc)
+	client := k8sfake.NewSimpleClientset(ns)
 	fakeAutoscaling := &autoscalingv1fake.FakeAutoscalingV1alpha1{Fake: &clienttesting.Fake{}}
 	autoscalingClient := func() (autoscalingv1client.AutoscalingV1alpha1Interface, error) {
 		return fakeAutoscaling, nil
@@ -143,13 +137,13 @@ func TestNewServiceLoadCommand(t *testing.T) {
 
 		cmd := NewServiceLoadCommand(p)
 		_, err := testutil.ExecuteCommand(cmd, "--svc-prefix", FakeServicePrefix, "--namespace", FakeNamespace, "--range", "0,0", "--load-tool", "hey", "--load-concurrency", FakeLoadConcurrency, "--load-duration", FakeLoadDuration, "--output", "./")
-		assert.NilError(t, err)
+		assert.ErrorContains(t, err, "no ksvc found with prefix "+FakeServicePrefix)
 
 		_, err = testutil.ExecuteCommand(cmd, "--svc-prefix", FakeServicePrefix, "--namespace", FakeNamespace, "--range", "0,0", "--load-tool", "wrk", "--load-concurrency", FakeLoadConcurrency, "--load-duration", FakeLoadDuration, "--verbose", "--output", "./")
-		assert.NilError(t, err)
+		assert.ErrorContains(t, err, "no ksvc found with prefix "+FakeServicePrefix)
 
 		_, err = testutil.ExecuteCommand(cmd, "--svc-prefix", FakeServicePrefix, "--namespace", FakeNamespace, "--range", "0,0", "--load-tool", "default", "--load-concurrency", FakeLoadConcurrency, "--load-duration", FakeLoadDuration, "--verbose", "--output", "./")
-		assert.NilError(t, err)
+		assert.ErrorContains(t, err, "no ksvc found with prefix "+FakeServicePrefix)
 	})
 }
 

--- a/pkg/command/service/load_test.go
+++ b/pkg/command/service/load_test.go
@@ -65,7 +65,13 @@ func TestNewServiceLoadCommand(t *testing.T) {
 			Name: FakeNamespace,
 		},
 	}
-	client := k8sfake.NewSimpleClientset(ns)
+	svc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      FakeServiceName,
+			Namespace: FakeNamespace,
+		},
+	}
+	client := k8sfake.NewSimpleClientset(ns, &svc)
 	fakeAutoscaling := &autoscalingv1fake.FakeAutoscalingV1alpha1{Fake: &clienttesting.Fake{}}
 	autoscalingClient := func() (autoscalingv1client.AutoscalingV1alpha1Interface, error) {
 		return fakeAutoscaling, nil

--- a/pkg/command/service/scale.go
+++ b/pkg/command/service/scale.go
@@ -136,7 +136,7 @@ func scaleAndMeasure(ctx context.Context, params *pkg.PerfParams, inputs pkg.Sca
 	if err != nil {
 		return result, err
 	}
-	objs, err := servicesListFunc(ctx, ksvcClient, nsNameList, inputs.Svc, inputs.SvcPrefix, inputs.SvcRange)
+	objs, err := servicesListFunc(ctx, ksvcClient, nsNameList, inputs.SvcPrefix, inputs.SvcRange, inputs.Svc)
 	if err != nil {
 		return result, err
 	}

--- a/pkg/command/service/scale_test.go
+++ b/pkg/command/service/scale_test.go
@@ -26,10 +26,9 @@ import (
 	"knative.dev/kperf/pkg"
 	networkingv1alpha1 "knative.dev/networking/pkg/client/clientset/versioned/typed/networking/v1alpha1"
 	fakenetworkingv1alpha1 "knative.dev/networking/pkg/client/clientset/versioned/typed/networking/v1alpha1/fake"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	autoscalingv1client "knative.dev/serving/pkg/client/clientset/versioned/typed/autoscaling/v1alpha1"
 	autoscalingv1fake "knative.dev/serving/pkg/client/clientset/versioned/typed/autoscaling/v1alpha1/fake"
-
-	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	servingv1client "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1"
 	servingv1fake "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1/fake"
 )
@@ -66,12 +65,12 @@ func TestScaleServces(t *testing.T) {
 
 	//"--svc-prefix", "svc", "--namespace", "ns1", "--range", "1,1")
 	scaleArgs := pkg.ScaleArgs{
-		SvcPrefix: "ksvc-",
+		SvcPrefix: "ksvc",
 		Namespace: "ns-1",
 		SvcRange:  "1,1",
 	}
 
-	getFakeServices := func(context.Context, servingv1client.ServingV1Interface, []string, string) []ServicesToScale {
+	getFakeServices := func(context.Context, servingv1client.ServingV1Interface, []string, string, string, string) ([]ServicesToScale, error) {
 		objs := []ServicesToScale{}
 		svc := ServicesToScale{
 			Service: &servingv1.Service{
@@ -89,7 +88,7 @@ func TestScaleServces(t *testing.T) {
 		}
 
 		objs = append(objs, svc)
-		return objs
+		return objs, nil
 	}
 
 	_, err := scaleAndMeasure(context.TODO(), p, scaleArgs, []string{"ns-1"}, getFakeServices)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,7 @@ var defaultServiceCommonFlags = map[string]bool{
 	"svc-prefix":       true,
 	"range":            true,
 	"output":           true,
+	"svc":              true,
 }
 
 // Initialize common flags in config file

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -72,6 +72,7 @@ type MeasureArgs struct {
 }
 
 type ScaleArgs struct {
+	Svc              string
 	SvcRange         string
 	Namespace        string
 	SvcPrefix        string
@@ -87,6 +88,7 @@ type ScaleArgs struct {
 }
 
 type LoadArgs struct {
+	Svc                   string
 	SvcRange              string
 	Namespace             string
 	SvcPrefix             string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- `getServices()` gets existed services by specified svc or (svc-prefix + svcRange)
  - :bug: Fixed svc range invalid bug in `getService()` which is used by scale and load command 
  - :gift: Add svc flag in load and scale to support specified svc by user
- AS `getService()` and `ServicesToScale` struct are common function of scale and load, so moved them to common.go

Fixes #304

# Test 
- Generate 5 services(ktest-0 ... ktest-4) by kperf, then use kperf  to load svc range (4,5)
```yaml
# ~/.config/kperf/config.yaml
service:
  output: /tmp
  generate:
    number: 5
    interval: 1
    batch: 1
    concurrency: 1
    namespace: ktest
    svc-prefix: ktest
  load:
    load-concurrency: 2
    load-duration: 2s
    verbose: true
    namespace: ktest
    svc-prefix: ktest
    range: 4,5
```

```bash
$ kperf service generate
$ kperf service load
2022/10/12 01:33:06 Namespace ktest, Service ktest-4, load start
```
- Use kperf to load existed ksvc hello
```yaml
service:
   output: /tmp
   namespace: default
   svc: hello
   load:
     load-concurrency: 2
     load-duration: 2s
     verbose: true
```
```bash
$ kperf service load
2022/10/12 07:31:15 Namespace default, Service hello, load start
```