### PR TITLE
Support POST in scale

### DIFF
--- a/pkg/types.go
+++ b/pkg/types.go
@@ -89,6 +89,10 @@ type ScaleArgs struct {
 	Iterations       int
 	TimeInterval     time.Duration
 	StableWindow     string
+	Method           string
+	Body             string
+	BodyFile         string
+	ContentType      string
 }
 
 type LoadArgs struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- add http request method choice for POST in scale, default method is GET
- support send data and file for POST body

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind enhancement

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #349 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Docs**

```shell
Usage:
  kperf service scale [flags]

Flags:
      --MaxRetries int            Maximum number of trying to poll the service (default 10)
  -c, --concurrency int           Number of workers to do measurement job (default 10)
  -C, --contentType string        Request ContentType (default "text/html")
  -D, --data string               Request body
  -F, --dataFile string           Request body with a file, such as json
  -h, --help                      help for scale
      --https                     Use https with TLS
  -i, --iterations int            Number of iterations to invoke the service (default 1)
  -m, --method string             Request method, support GET and POST (default "GET")
      --namespace string          Service namespace
      --namespace-prefix string   Service namespace prefix
      --namespace-range string    Service namespace range
  -o, --output string             Measure result location (default ".")
  -r, --range string              Desired service range
      --resolvable                If Service endpoint resolvable url
  -s, --stable-window string      stable window per revision (default "6s")
      --svc string                Service name
      --svc-prefix string         Service name prefix
  -T, --time-interval duration    The time interval of each scale up, recommend to set it no less than the sum of the stable window and cold startup time (default 10s)
      --timeout duration          Duration to wait for Knative Service to be ready (default 2s)
  -v, --verbose                   Service verbose result
      --wait duration             Time to wait before retring to call the Knatice Service (default 2s)

Global Flags:
      --config string   kperf configuration file (default "/home/yangge/.config/kperf/config.yaml")
```

**Examples**

Create an knative service to display received POST request

```shell
wget https://raw.githubusercontent.com/chzhyang/faas-workloads/coldstart/knative-samples/request-display/request-display.yaml

kubectl apply -f request-display.yaml
```
Send data in POST

  ```shell
  kperf service scale --namespace default --svc request-display \
  --verbose --output /tmp \
  -m POST -D '{"key1":"value1", "key2":"value2"}' -C application/json

  scale up service default/request-display in 1 iterations:
  ====================== service default/request-display result =====================
  iteration    0, service latency: 2.290199 s, deployment latency: 0.036729 s
  service latency result:
  Average: 2.290199 s
  Min:     2.290199 s
  Max:     2.290199 s
  P50:     2.290199 s
  P90:     2.290199 s
  P95:     2.290199 s
  P99:     2.290199 s
  deployment latency result:
  Average: 0.036729 s
  Min:     0.036729 s
  Max:     0.036729 s
  P50:     0.036729 s
  P90:     0.036729 s
  P95:     0.036729 s
  P99:     0.036729 s
  Measurement saved in CSV file /tmp/20230314052830_ksvc_scaling_time.csv
  Visualized measurement saved in HTML file /tmp/20230314052830_ksvc_scaling_time.html
  Measurement saved in JSON file /tmp/20230314052830_ksvc_scaling_time.json

  $ k logs request-display-00001-deployment-69546d444c-g9rqb 
  Defaulted container "user-container" out of: user-container, queue-proxy
  2023-03-14 05:28:29,251::INFO::Serving on http://0.0.0.0:8080
  2023-03-14 05:28:30,224::WARNING::No CloudEvent available
  2023-03-14 05:28:30,224::INFO::Received a POST request: {"key1":"value1", "key2":"value2"}
  ```

Send file in POST
  ```shell
  # get cloudevents.Event file
  wget https://raw.githubusercontent.com/chzhyang/faas-workloads/coldstart/tf-knative-event-ceph/wrk-cloudevent/event.json

  kperf service scale --namespace default --svc request-display \
  --verbose --output /tmp \
  -m POST -F event.json -C application/cloudevents+json

  scale up service default/request-display in 1 iterations:
  ====================== service default/request-display result =====================
  iteration    0, service latency: 3.102239 s, deployment latency: 0.786127 s
  service latency result:
  Average: 3.102239 s
  Min:     3.102239 s
  Max:     3.102239 s
  P50:     3.102239 s
  P90:     3.102239 s
  P95:     3.102239 s
  P99:     3.102239 s
  deployment latency result:
  Average: 0.786127 s
  Min:     0.786127 s
  Max:     0.786127 s
  P50:     0.786127 s
  P90:     0.786127 s
  P95:     0.786127 s
  P99:     0.786127 s
  Measurement saved in CSV file /tmp/20230314052612_ksvc_scaling_time.csv
  Visualized measurement saved in HTML file /tmp/20230314052612_ksvc_scaling_time.html
  Measurement saved in JSON file /tmp/20230314052612_ksvc_scaling_time.json

  $ k logs request-display-00002-deployment-69546d444c-v5f9s 
  Defaulted container "user-container" out of: user-container, queue-proxy
  2023-03-14 05:26:11,488::INFO::Serving on http://0.0.0.0:8080
  2023-03-14 05:26:12,518::INFO::Reveived cloudevents.Event from ceph:s3, event id is curl.event.1
  ```